### PR TITLE
fix padding error

### DIFF
--- a/Themes/GGO_Kirito/core.css
+++ b/Themes/GGO_Kirito/core.css
@@ -288,7 +288,7 @@
         #app-mount .message-2CShn3 .container-2sjPya,
         #app-mount .message-2CShn3 .contents-2MsGLg {
             background-color: var(--secondary1-colour);
-            padding: 5px 0px 5px 20px;
+            padding: 5px 0px 5px 72px;
         }
         #app-mount .buttonContainer-1502pf .wrapper-2vIMkT {
             background-color: var(--secondary1-colour);


### PR DESCRIPTION
There was a padding error that made it impossible to read the timestamps of messages and identify their senders.
![Before](https://github.com/VaporousCreeper/BetterDiscord-ThemesAndPlugins/assets/100975302/68b755f5-4ef2-4612-bd72-c31d9d399b15)

Added a bit more padding-left space.
![After](https://github.com/VaporousCreeper/BetterDiscord-ThemesAndPlugins/assets/100975302/57585cd2-51dd-47d4-a652-9751148ab24a)